### PR TITLE
if both types are proto messages, use proto.Equal

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/protobuf/proto"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -56,6 +57,15 @@ type Comparison func() (success bool)
 func ObjectsAreEqual(expected, actual interface{}) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
+	}
+
+	expProto, ok := expected.(proto.Message)
+	if ok {
+		actProto, ok := actual.(proto.Message)
+		if ok {
+			// if both are protobuf messages, use `proto.Equal`
+			return proto.Equal(expProto, actProto)
+		}
 	}
 
 	exp, ok := expected.([]byte)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -126,11 +126,11 @@ func TestObjectsAreEqual(t *testing.T) {
 		t.Error("objectsAreEqual should return false")
 	}
 	if !ObjectsAreEqual(
-		test_proto.GoTestField{
+		&test_proto.GoTestField{
 			Label: proto.String("123"),
 			Type:  proto.String("abc"),
 		},
-		test_proto.GoTestField{
+		&test_proto.GoTestField{
 			Label: proto.String("123"),
 			Type:  proto.String("abc"),
 		},
@@ -138,12 +138,12 @@ func TestObjectsAreEqual(t *testing.T) {
 		t.Error("objectsAreEqual should return true")
 	}
 	if !ObjectsAreEqual(
-		test_proto.GoTestField{
+		&test_proto.GoTestField{
 			Label:         proto.String("123"),
 			Type:          proto.String("abc"),
 			XXX_sizecache: 1,
 		},
-		test_proto.GoTestField{
+		&test_proto.GoTestField{
 			Label:         proto.String("123"),
 			Type:          proto.String("abc"),
 			XXX_sizecache: 2,

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -14,6 +14,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto/test_proto"
 )
 
 var (
@@ -121,6 +124,32 @@ func TestObjectsAreEqual(t *testing.T) {
 	}
 	if ObjectsAreEqual('x', "x") {
 		t.Error("objectsAreEqual should return false")
+	}
+	if !ObjectsAreEqual(
+		test_proto.GoTestField{
+			Label: proto.String("123"),
+			Type:  proto.String("abc"),
+		},
+		test_proto.GoTestField{
+			Label: proto.String("123"),
+			Type:  proto.String("abc"),
+		},
+	) {
+		t.Error("objectsAreEqual should return true")
+	}
+	if !ObjectsAreEqual(
+		test_proto.GoTestField{
+			Label:         proto.String("123"),
+			Type:          proto.String("abc"),
+			XXX_sizecache: 1,
+		},
+		test_proto.GoTestField{
+			Label:         proto.String("123"),
+			Type:          proto.String("abc"),
+			XXX_sizecache: 2,
+		},
+	) {
+		t.Error("objectsAreEqual should return true") // different XXX_sizecache is still equal for proto
 	}
 	if ObjectsAreEqual("x", 'x') {
 		t.Error("objectsAreEqual should return false")

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/stretchr/testify
 
 require (
 	github.com/davecgh/go-spew v1.1.0
+	github.com/golang/protobuf v1.1.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/objx v0.1.0
+	golang.org/x/sync v0.0.0-20190412183630-56d357773e84 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+golang.org/x/sync v0.0.0-20190412183630-56d357773e84 h1:IqXQ59gzdXv58Jmm2xn0tSOR9i6HqroaOFRQ3wR/dJQ=
+golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Context

golang/protobuf 1.0.0 contained a few major changes, one of which was the addition of a new field:

> An `XXX_sizecache` field that is part of the internal implementation of the table-driven serializer. The presence of this field can break tests that use `reflect.DeepEqual` to compare some received messages with some golden message. It is recommended that `proto.Equal` be used instead for this situation.

- https://groups.google.com/forum/#!topic/golang-nuts/F5xFHTfwRnY

As noted, the presence of these new fields breaks test assertions.

## Description

This PR modifies the behavior for `ObjectsAreEqual` which is used by assertion methods like `assert.Equal` to support equality checks for protobuf messages.

This allows us to transparently compare protobufs messages without breaking existing tests even if they have different underlying `XXX_` values. This is recommended by the protobuf team.

The alternative is create another assertion method specific to protobuf, then migrate every existing assertions that compares two protobuf messages to use the new assertion method. Even then, it does not cover cases like slices or maps that may contain protobuf messages. I think forking the assertion library is the most straight-forward solution with relative low-cost, as this is a relatively simple library, it should be easy to keep the forks in sync.

Also, I don't think it's likely that this will be accepted upstream as it would introduce the protobuf dependency to all users even thought they may not be using protobuf. I might try to suggest using a compiler flag upstream to make this functionality optional, but I don't think it should block our own upgrades.

## Testing

- unit tests in the library
- internal tests against the go repo